### PR TITLE
Don't rely on InclusiveNamespaces for namespace declarations

### DIFF
--- a/lib/saml2.coffee
+++ b/lib/saml2.coffee
@@ -396,10 +396,10 @@ add_namespaces_to_child_assertions = (xml_string) ->
     assertion_element = assertion_elements[0]
 
     inclusive_namespaces = assertion_element.getElementsByTagNameNS(XMLNS.EXC_C14N, 'InclusiveNamespaces')[0]
-    if inclusive_namespaces and prefixList = inclusive_namespaces.getAttribute('PrefixList')?.trim()
-      namespaces = prefixList.split(' ').map (ns) -> "xmlns:#{ns}"
+    namespaces = if inclusive_namespaces and prefixList = inclusive_namespaces.getAttribute('PrefixList')?.trim()
+      ("xmlns:#{ns}" for ns in prefixList.split(' '))
     else
-      namespaces = (attr.name for attr in response_element.attributes when attr.name.startsWith 'xmlns:')
+      (attr.name for attr in response_element.attributes when attr.name.startsWith 'xmlns:')
 
     # add the namespaces that are present in response and missing in assertion.
     for ns in namespaces

--- a/lib/saml2.coffee
+++ b/lib/saml2.coffee
@@ -394,17 +394,18 @@ add_namespaces_to_child_assertions = (xml_string) ->
     assertion_elements = response_element.getElementsByTagNameNS XMLNS.SAML, 'Assertion'
     return xml_string if assertion_elements.length isnt 1
     assertion_element = assertion_elements[0]
-    return xml_string if assertion_element.getElementsByTagNameNS(XMLNS.DS, 'Signature').length is 0
 
     inclusive_namespaces = assertion_element.getElementsByTagNameNS(XMLNS.EXC_C14N, 'InclusiveNamespaces')[0]
-    return xml_string if not inclusive_namespaces
-    prefix_list = inclusive_namespaces.getAttribute('PrefixList')
+    if inclusive_namespaces
+      namespaces = inclusive_namespaces.getAttribute('PrefixList').split(' ').map (ns) -> "xmlns:#{ns}"
+    else
+      namespaces = (attr.name for attr in response_element.attributes when attr.name.startsWith 'xmlns:')
 
     # add the namespaces that are present in response and missing in assertion.
-    for ns in prefix_list.split ' '
-      if response_element.getAttribute('xmlns:' + ns) and !assertion_element.getAttribute('xmlns:' + ns)
-        new_attribute = doc.createAttribute 'xmlns:' + ns
-        new_attribute.value = response_element.getAttribute 'xmlns:' + ns
+    for ns in namespaces
+      if response_element.getAttribute(ns) and !assertion_element.getAttribute(ns)
+        new_attribute = doc.createAttribute ns
+        new_attribute.value = response_element.getAttribute ns
         assertion_element.setAttributeNode new_attribute
 
     return new xmldom.XMLSerializer().serializeToString response_element
@@ -666,5 +667,6 @@ if process.env.NODE_ENV is "test"
   module.exports.get_name_id = get_name_id
   module.exports.get_session_index = get_session_index
   module.exports.parse_assertion_attributes = parse_assertion_attributes
+  module.exports.add_namespaces_to_child_assertions = add_namespaces_to_child_assertions
   module.exports.set_option_defaults = set_option_defaults
   module.exports.extract_certificate_data = extract_certificate_data

--- a/lib/saml2.coffee
+++ b/lib/saml2.coffee
@@ -396,8 +396,8 @@ add_namespaces_to_child_assertions = (xml_string) ->
     assertion_element = assertion_elements[0]
 
     inclusive_namespaces = assertion_element.getElementsByTagNameNS(XMLNS.EXC_C14N, 'InclusiveNamespaces')[0]
-    if inclusive_namespaces
-      namespaces = inclusive_namespaces.getAttribute('PrefixList').split(' ').map (ns) -> "xmlns:#{ns}"
+    if inclusive_namespaces and prefixList = inclusive_namespaces.getAttribute('PrefixList')?.trim()
+      namespaces = prefixList.split(' ').map (ns) -> "xmlns:#{ns}"
     else
       namespaces = (attr.name for attr in response_element.attributes when attr.name.startsWith 'xmlns:')
 

--- a/test/data/namespaced_assertion.xml
+++ b/test/data/namespaced_assertion.xml
@@ -1,0 +1,5 @@
+<?xml version="1.0"?>
+<samlp:Response xmlns:samlp="urn:oasis:names:tc:SAML:2.0:protocol" xmlns:saml="urn:oasis:names:tc:SAML:2.0:assertion">
+    <saml:Assertion xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:xs="http://www.w3.org/2001/XMLSchema">
+    </saml:Assertion>
+</samlp:Response>

--- a/test/data/namespaced_assertion_with_empty_inclusivenamespaces.xml
+++ b/test/data/namespaced_assertion_with_empty_inclusivenamespaces.xml
@@ -1,0 +1,16 @@
+<?xml version="1.0"?>
+<samlp:Response xmlns:samlp="urn:oasis:names:tc:SAML:2.0:protocol" xmlns:saml="urn:oasis:names:tc:SAML:2.0:assertion" xmlns:foo="bar">
+    <saml:Assertion xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:xs="http://www.w3.org/2001/XMLSchema">
+        <ds:Signature Id="uuid7ffae679-0152-14e0-bd4f-dff79ed21b90">
+            <ds:SignedInfo>
+                <ds:Reference URI="#Assertion-uuid7ffae65d-0152-16c9-80a3-dff79ed21b90">
+                    <ds:Transforms>
+                        <ds:Transform Algorithm="http://www.w3.org/2001/10/xml-exc-c14n#">
+                            <xc14n:InclusiveNamespaces xmlns:xc14n="http://www.w3.org/2001/10/xml-exc-c14n#" PrefixList=""></xc14n:InclusiveNamespaces>
+                        </ds:Transform>
+                    </ds:Transforms>
+                </ds:Reference>
+            </ds:SignedInfo>
+        </ds:Signature>
+    </saml:Assertion>
+</samlp:Response>

--- a/test/data/namespaced_assertion_with_inclusivenamespaces.xml
+++ b/test/data/namespaced_assertion_with_inclusivenamespaces.xml
@@ -1,0 +1,16 @@
+<?xml version="1.0"?>
+<samlp:Response xmlns:samlp="urn:oasis:names:tc:SAML:2.0:protocol" xmlns:saml="urn:oasis:names:tc:SAML:2.0:assertion" xmlns:foo="bar">
+    <saml:Assertion xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:xs="http://www.w3.org/2001/XMLSchema">
+        <ds:Signature Id="uuid7ffae679-0152-14e0-bd4f-dff79ed21b90">
+            <ds:SignedInfo>
+                <ds:Reference URI="#Assertion-uuid7ffae65d-0152-16c9-80a3-dff79ed21b90">
+                    <ds:Transforms>
+                        <ds:Transform Algorithm="http://www.w3.org/2001/10/xml-exc-c14n#">
+                            <xc14n:InclusiveNamespaces xmlns:xc14n="http://www.w3.org/2001/10/xml-exc-c14n#" PrefixList="samlp saml xsi xs"></xc14n:InclusiveNamespaces>
+                        </ds:Transform>
+                    </ds:Transforms>
+                </ds:Reference>
+            </ds:SignedInfo>
+        </ds:Signature>
+    </saml:Assertion>
+</samlp:Response>

--- a/test/saml2.coffee
+++ b/test/saml2.coffee
@@ -276,6 +276,20 @@ describe 'saml2', ->
         assert.deepEqual attributes, {}
 
     describe 'add_namespaces_to_child_assertions', ->
+      it 'adds namespaces defined by InclusiveNamespaces', ->
+        response = saml2.add_namespaces_to_child_assertions get_test_file('namespaced_assertion_with_inclusivenamespaces.xml')
+        dom = (new xmldom.DOMParser()).parseFromString response
+        assertion = dom.getElementsByTagNameNS('urn:oasis:names:tc:SAML:2.0:assertion', 'Assertion')
+        attributes = (attr.name for attr in assertion[0].attributes)
+        assert.deepEqual attributes, [
+          'xmlns:xsi'
+          'xmlns:xs'
+          'xmlns:samlp'
+          'xmlns:saml'
+        ]
+        # shouldn't have copied the namespace from the Response element
+        assert.equal attributes.includes('xmlns:foo'), false
+
       it 'copies namespaces from Response to Assertion if there is no InclusiveNamespaces', ->
         response = saml2.add_namespaces_to_child_assertions get_test_file('namespaced_assertion.xml')
         dom = (new xmldom.DOMParser()).parseFromString response

--- a/test/saml2.coffee
+++ b/test/saml2.coffee
@@ -275,6 +275,19 @@ describe 'saml2', ->
         attributes = saml2.parse_assertion_attributes dom_from_test_file('blank_assertion.xml')
         assert.deepEqual attributes, {}
 
+    describe 'add_namespaces_to_child_assertions', ->
+      it 'copies namespaces from Response to Assertion if there is no InclusiveNamespaces', ->
+        response = saml2.add_namespaces_to_child_assertions get_test_file('namespaced_assertion.xml')
+        dom = (new xmldom.DOMParser()).parseFromString response
+        assertion = dom.getElementsByTagNameNS('urn:oasis:names:tc:SAML:2.0:assertion', 'Assertion')
+        attributes = (attr.name for attr in assertion[0].attributes)
+        assert.deepEqual attributes, [
+          'xmlns:xsi'
+          'xmlns:xs'
+          'xmlns:samlp'
+          'xmlns:saml'
+        ]
+
     describe 'set option defaults', ->
       it 'sets defaults in the correct order', ->
         options_top =

--- a/test/saml2.coffee
+++ b/test/saml2.coffee
@@ -302,6 +302,19 @@ describe 'saml2', ->
           'xmlns:saml'
         ]
 
+      it 'copies namespaces from Response to Assertion if there is an empty InclusiveNamespaces', ->
+        response = saml2.add_namespaces_to_child_assertions get_test_file('namespaced_assertion_with_empty_inclusivenamespaces.xml')
+        dom = (new xmldom.DOMParser()).parseFromString response
+        assertion = dom.getElementsByTagNameNS('urn:oasis:names:tc:SAML:2.0:assertion', 'Assertion')
+        attributes = (attr.name for attr in assertion[0].attributes)
+        assert.deepEqual attributes, [
+          'xmlns:xsi'
+          'xmlns:xs'
+          'xmlns:samlp'
+          'xmlns:saml'
+          'xmlns:foo'
+        ]
+
     describe 'set option defaults', ->
       it 'sets defaults in the correct order', ->
         options_top =


### PR DESCRIPTION
(This PR mirrors [Clever/saml2#81](https://github.com/Clever/saml2/pull/81/) and is here for our internal purposes in case there's a long wait on saml2-js)

The `add_namespaces_to_child_assertions` function [assumes the presence of an
InclusiveNamespaces
element](https://github.com/Clever/saml2/blob/6cad30fb1e0e9a59ae850f7de6bed4310a403ba9/lib/saml2.coffee#L399)
from which it will read a list of namespaces.

If this is present, any namespace definitions declared by InclusiveNamespaces
are copied from the Response element to the Assertion. Then, when the Assertion
element is handled in isolation from the rest of the Response document, the
namespaces are all still defined.

However if the InclusiveNamespaces element is not found, no namespaces are
copied. If then the Assertion element is namespaced (e.g. `<saml:Assertion>`),
it [will not be
found](https://github.com/Clever/saml2/blob/6cad30fb1e0e9a59ae850f7de6bed4310a403ba9/lib/saml2.coffee#L440)
and the document will be treated as not having an assertion at all.

If there is an InclusiveNamespaces element, we will continue to use that as
before to read the namespaces to apply to the Assertion element.

However if there is none (or it's empty), we'll just read all the namespaces from the Response
element onto the Assertion element.

This should ensure all the necessary namespaces are defined when the Assertion is used out of context, such as to validate the signature.
